### PR TITLE
Add outbound access argument to subnets

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -62,6 +62,7 @@ module "vnet" {
     }
     subnet2 = {
       address_prefixes = ["10.0.2.0/24"]
+      default_outbound_access_enabled = false
       nat_gateway = {
         id = azurerm_nat_gateway.example.id
       }

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ resource "azurerm_subnet" "subnet" {
   private_link_service_network_policies_enabled = each.value.private_link_service_network_policies_enabled
   service_endpoint_policy_ids                   = each.value.service_endpoint_policy_ids
   service_endpoints                             = each.value.service_endpoints
+  default_outbound_access_enabled               = each.value.default_outbound_access_enabled
 
   dynamic "delegation" {
     for_each = each.value.delegations == null ? [] : each.value.delegations

--- a/test/unit/unit_test.go
+++ b/test/unit/unit_test.go
@@ -20,6 +20,7 @@ type subnet struct {
 	Route_table                                   *routeTable `mapstructure:"route_table,omitempty"`
 	Service_endpoints                             []string    `mapstructure:"service_endpoints,omitempty"`
 	Service_endpoint_policy_ids                   []string    `mapstructure:"service_endpoint_policy_ids,omitempty"`
+	Default_outbound_access_enabled 			  bool        `mapstructure:"default_outbound_access_enabled,omitempty"`
 	Delegations                                   []struct {
 		Name               string `mapstructure:"name"`
 		Service_delegation struct {

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,7 @@ variable "subnets" {
       }))
       service_endpoints           = optional(set(string)) # (Optional) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.ContainerRegistry`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql`, `Microsoft.Storage` and `Microsoft.Web`.
       service_endpoint_policy_ids = optional(set(string)) # (Optional) The list of IDs of Service Endpoint Policies to associate with the subnet.
+      default_outbound_access_enabled = optional(bool, true) # (Optional) Enable default outbound access to the internet for the subnet. Defaults to `true`.
       delegations = optional(list(
         object(
           {


### PR DESCRIPTION
## Describe your changes

Added `default_outbound_access_enabled` field to subnets to allow setting its value.
Field description: Enable default outbound access to the internet for the subnet. Defaults to `true`.

## Issue number

#000

## Checklist before requesting a review
- [X] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

